### PR TITLE
Prettier for Windows line endings fix

### DIFF
--- a/rule-sets/base.js
+++ b/rule-sets/base.js
@@ -207,6 +207,7 @@ export const baseRuleSet = {
       'error',
       {
         arrowParens: 'avoid',
+        endOfLine: 'auto',
         singleQuote: true,
         trailingComma: 'all',
       },


### PR DESCRIPTION
Git by default switches line ending to the native one for the OS when checking out code, this allows Prettier to accept that (even if a different standard is set in `.editorconfig`).